### PR TITLE
Add YAML config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,16 @@ project_root/
 
 ### **总结**
 这个更新后的 `README.md` 更加清晰地展示了项目的结构，特别是对多任务模型和自定义层的支持。你可以直接将其替换到你的项目中，方便团队成员快速理解项目结构。
+---
+
+### YAML Configuration
+
+`amp.utils` 提供 `load_yaml_config` 函数用于读取 YAML 配置文件。
+`ModelModule` 及其子类新增 `from_yaml` 方法，可以直接从 YAML
+文件实例化模型。
+
+```python
+from amp.model.ml.svm import SVM
+
+model = SVM.from_yaml("configs/model/svm.yaml")
+```

--- a/amp/__init__.py
+++ b/amp/__init__.py
@@ -1,0 +1,5 @@
+"""AMP core package."""
+
+from .utils import load_yaml_config
+
+__all__ = ["load_yaml_config"]

--- a/amp/model/ml/base.py
+++ b/amp/model/ml/base.py
@@ -22,6 +22,23 @@ class ModelModule(ABC):
         """
         return cls(**dict(cfg))
 
+    @classmethod
+    def from_yaml(cls, path: str):
+        """Instantiate the model from a YAML configuration file.
+
+        The YAML file should contain key-value pairs that match the
+        constructor arguments of the concrete model class.
+
+        Parameters
+        ----------
+        path : str
+            Path to the YAML configuration file.
+        """
+        from amp.utils import load_yaml_config
+
+        cfg = load_yaml_config(path)
+        return cls(**cfg)
+
     @abstractmethod
     def build(self):
         """

--- a/amp/utils/__init__.py
+++ b/amp/utils/__init__.py
@@ -1,0 +1,3 @@
+from .config import load_yaml_config
+
+__all__ = ["load_yaml_config"]

--- a/amp/utils/config.py
+++ b/amp/utils/config.py
@@ -1,0 +1,19 @@
+import yaml
+from typing import Any, Dict
+
+
+def load_yaml_config(path: str) -> Dict[str, Any]:
+    """Load a YAML configuration file.
+
+    Parameters
+    ----------
+    path : str
+        Path to the YAML file.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Parsed configuration dictionary.
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         "black>=21.7b0",
         "flake8>=3.9.2",
         "isort>=5.9.3",
+        "pyyaml>=6.0",
     ],
     python_requires=">=3.10",
 )


### PR DESCRIPTION
## Summary
- add YAML config loader utility
- support `from_yaml` in model base class
- expose loader via `amp` package
- update setup requirements and docs

## Testing
- `pytest -q`